### PR TITLE
Update to fix settings and support latest plugin best practices

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,0 +1,7 @@
+en:
+  site_settings:
+    jwt_enabled: 'JWT authentication is enabled'
+    jwt_auth_url: 'JWT auth URL'
+    jwt_secret: 'JWT shared secret'
+    jwt_button_title: 'Button title for JWT login'
+    jwt_email_verified: 'Check if the JWT provider has verified the email'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,10 @@
+login:
+  jwt_enabled:
+    default: false
+    client: true
+  jwt_auth_url: ''
+  jwt_secret: ''
+  jwt_button_title:
+    default: 'with JWT'
+    client: true
+  jwt_email_verified: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,22 +1,24 @@
 # name: discourse-jwt
 # about: JSON Web Tokens Auth Provider
-# version: 0.1
-# author: Robin Ward
+# version: 0.2
+# author: Robin Ward, Zach Schneider
 
 require_dependency 'auth/oauth2_authenticator'
 
-gem "discourse-omniauth-jwt", "0.0.2", require: false
+enabled_site_setting :jwt_enabled
+
+gem 'discourse-omniauth-jwt', '0.0.2', require: false
 
 require 'omniauth/jwt'
 
 class JWTAuthenticator < ::Auth::OAuth2Authenticator
   def register_middleware(omniauth)
     omniauth.provider :jwt,
-                      :name => 'jwt',
-                      :uid_claim => 'id',
-                      :required_claims => ['id', 'email', 'name'],
-                      :secret => GlobalSetting.jwt_secret,
-                      :auth_url => GlobalSetting.jwt_auth_url
+                      name: 'jwt',
+                      uid_claim: 'id',
+                      required_claims: ['id', 'email', 'name'],
+                      secret: SiteSetting.jwt_secret,
+                      auth_url: SiteSetting.jwt_auth_url
   end
 
   def after_authenticate(auth)
@@ -24,30 +26,29 @@ class JWTAuthenticator < ::Auth::OAuth2Authenticator
 
     uid = auth[:uid]
     result.name = auth[:info].name
-    result.username = uid
+    result.username = auth[:info].name.tr(' ', '_')
     result.email = auth[:info].email
     result.email_valid = true
 
-    current_info = ::PluginStore.get("jwt", "jwt_user_#{uid}")
+    current_info = ::PluginStore.get('jwt', "jwt_user_#{uid}")
     if current_info
       result.user = User.where(id: current_info[:user_id]).first
+    elsif SiteSetting.jwt_email_verified?
+      result.user = User.where(email: Email.downcase(result.email)).first
     end
     result.extra_data = { jwt_user_id: uid }
     result
   end
 
   def after_create_account(user, auth)
-    ::PluginStore.set("jwt", "jwt_user_#{auth[:extra_data][:jwt_user_id]}", {user_id: user.id })
+    ::PluginStore.set('jwt', "jwt_user_#{auth[:extra_data][:jwt_user_id]}", {user_id: user.id })
   end
-
 end
 
-title = GlobalSetting.try(:jwt_title) || "JWT"
-button_title = GlobalSetting.try(:jwt_title) || "with JWT"
-
-auth_provider :title => button_title,
-              :authenticator => JWTAuthenticator.new('jwt'),
-              :message => "Authorizing with #{title} (make sure pop up blockers are not enabled)",
-              :frame_width => 600,
-              :frame_height => 380,
-              :background_color => '#003366'
+auth_provider title_setting: 'jwt_button_title',
+              enabled_setting: 'jwt_enabled',
+              authenticator: JWTAuthenticator.new('jwt'),
+              message: 'Authorizing (make sure pop up blockers are not enabled)',
+              frame_width: 600,
+              frame_height: 380,
+              background_color: '#003366'


### PR DESCRIPTION
- Add settings YML and en translation
- Access via SiteSetting rather than broken GlobalSetting
- Adjust provider config to better use settings
- Clean up ruby style of plugin.rb
- Generate username by transforming name, not from ID
- Add jwt_email_verified option to allow matching current users
